### PR TITLE
Update AuthorizationCallback.cs

### DIFF
--- a/src/DeviceAuthService/AuthorizationCallback.cs
+++ b/src/DeviceAuthService/AuthorizationCallback.cs
@@ -34,7 +34,7 @@ namespace Ltwlf.Azure.B2C
 
         [FunctionName("authorization_callback")]
         public async Task<IActionResult> RunAsync(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "authorization_callback")]
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "authorization_callback")]
             HttpRequest req, ILogger log, ExecutionContext context)
         {
             log.LogInformation("authorization_callback function processed a request.");
@@ -44,9 +44,10 @@ namespace Ltwlf.Azure.B2C
                 return _pageFactory.GetPageResult(PageFactory.PageType.Error);
             }
 
-            string code = req.Query["code"];
-            string userCode = req.Query["state"];
-            
+            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+            String code = HttpUtility.ParseQueryString(requestBody).Get("code");
+            String userCode = HttpUtility.ParseQueryString(requestBody).Get("state");
+                        
             var authState = await Helpers.GetValueByKeyPattern<AuthorizationState>(_muxer, $"*:{userCode}");
             if (authState == null)
             {


### PR DESCRIPTION
Implementing response_type=form_post to avoid the issue of exceeding the maxQueryStringLength="4096"  in the URL when a large code is returned and changing the code to read from the body.
https://github.com/Azure/azure-functions-host/blob/v1.x/src/WebJobs.Script.WebHost/Web.config#L38